### PR TITLE
Criado arquivo de conexao com banco de dados

### DIFF
--- a/Stone.Infrastructure/DataContextLayer/EFDataContext.cs
+++ b/Stone.Infrastructure/DataContextLayer/EFDataContext.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Stone.Infrastructure.DataContextLayer
+{
+    class EFDataContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlServer(@"Data Source = (localdb)\MSSQLLocalDB; Initial Catalog = master; Integrated Security = True; Connect Timeout = 30; Encrypt = False; TrustServerCertificate = False; ApplicationIntent = ReadWrite; MultiSubnetFailover = False");
+        }
+    }
+}


### PR DESCRIPTION
O DataContext é a origem de todas as entidades mapeadas em uma conexão de banco de dados.
Dessa forma, após criar uma nova classe, realizar o mapeamento neste arquivo.